### PR TITLE
Integrated Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+language: node_js
+node_js:
+  - "4.2"
+
+# To reduce noise for other contributors,
+# we are whitelisting Travis CI to only build for `master`
+# DEV: If you would like your branch to build,
+#   then temporarily add it to this list
+#   but also remove `notifications` settings
+branches:
+  only:
+    - master
+
+script:
+  # DEV: Currently our test suite runs locally only
+  #   This should be resolved in #19
+  - npm run lint
+
+notifications:
+  email:
+    recipients:
+      - todd@twolfson.com
+    on_success: change
+    on_failure: change

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# google-music.js
+# google-music.js [![Build Status](https://travis-ci.org/twolfson/google-music.js.svg?branch=master)](https://travis-ci.org/twolfson/google-music.js)
 
 Browser-side JS library for controlling [Google Music][].
 


### PR DESCRIPTION
As discussed in #19, we want to have Travis CI set up so #19 can land green. In this PR:
- Integrated Travis CI and added `.travis.yml`
- Added Travis CI badge for `master` branch to README

**Notes:**

Due to nightly builds as discussed in #19, we want to set up `notifications/email` to email all contributors to let them know about the broken build. Unfortunately, due to us pushing commits to other branches, this could get noisy quickly.

After some research, it looks like Travis CI doesn't support per-branch notifications and we have confirmed that nightlies doesn't have its own notification system:

https://github.com/coderanger/nightlies/blob/ef74410486b9060fda0737a9645ab3ec02cfe696/model.rb#L94-L107

As a result, we are adding a whitelist to only build for the `master` branch.
