### PR TITLE
Added missing webdriver-manager-update command and added test-windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,11 +344,16 @@ browser.allCookies(function (err, cookies) { fs.writeFileSync('test/cookies.json
 Finally, we can run the test suite:
 
 ```bash
+# Install Selenium server files
+npm run webdriver-manager-update
+
 # Start up a Selenium server
 npm run webdriver-manager-start &
 
 # Run our tests
 npm test
+# If you are on Windows, please use
+# npm run test-windows
 ```
 
 #### Debugging

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
     "lint": "twolfson-style lint lib/ test/",
     "pretest": "npm run build",
     "test": "npm run verify-webdriver && mocha --timeout 10000 --reporter dot && npm run lint",
+    "test-windows": "npm run pretest && mocha --timeout 10000 --reporter dot && npm run lint",
     "verify-webdriver": "curl --silent http://localhost:4444/ > /dev/null || (echo \"Selenium server wasn't started. Please start it via \\`npm run webdriver-manager-start\\`.\" 1>&2 && exit 1)",
-    "webdriver-manager-start": "webdriver-manager start"
+    "webdriver-manager-start": "webdriver-manager start",
+    "webdriver-manager-update": "webdriver-manager update --standalone"
   },
   "dependencies": {
     "inherits": "~2.0.1"


### PR DESCRIPTION
Based on feedback from @MarshallOfSound in #19, it sounded like some things in our test suite were broken from Windows. After some digging, we found a couple issues which have been resolved in this PR (some of which were mentioned in #19).

In this PR:
- Added missing `webdriver-manager-update` command and documentation
  - We never properly set up/documented how to get a Selenium JAR installed. This was a missing step preventing people from approaching our test suite
- Added `npm run test-windows` command and documentation
  - Windows lacks any native command like `curl` and the only JS based alternative we found didn't have any failure for an `ECONNREFUSED`. As an interim solution, we are skipping the `npm run verify-webdriver` for Selenium

**Notes:**

After correcting these one-offs, I was able to get the test suite running on a Windows VM :tada: 

/cc @MarshallOfSound 
