### PR TITLE
Documented release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,22 @@ Due to the brittle nature of `google-music.js`, we must be flexible to allow for
     - If you don't hear from anyone else, then use your best judgement to land the PR or not
 - If the issue is not time sensitive, please wait for at least 1 other core contributor to approve the PR (e.g. via a ":+1:", ":shipit:", or "lgtm")
     - If the PR is a large change (e.g. refactoring the library), then please use your judgement and consider waiting for more contributors
+
+## Release process
+To guarantee consistent releases across core contributors, we use [foundry][] to perform our releases. To perform a release, use the following steps:
+
+- Checkout master `git checkout master`
+- Merge pull request branch either via GitHub UI or CLI
+    - CLI instructions: https://gist.github.com/piscisaureus/3342247
+- Update `CHANGELOG.md` to include latest release info
+    - Determine latest version based on [SemVer][]
+- Stage `CHANGELOG.md` changes
+    - `git add -p`
+- Perform release via `foundry`
+    - Install `foundry.cli` globally via `npm install -g foundry.cli`
+    - `foundry release {{version}}`
+        - For example, `foundry release 3.5.0`
+    - Under the hood, this will run `npm run build`, update the `package.json`, use `git commit`, use `git tag`, and `npm publish`
+
+[foundry]: https://github.com/twolfson/foundry
+[SemVer]: http://semver.org/

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
   ],
   "foundry": {
     "releaseCommands": [
+      {
+        "type": "customCommand",
+        "updateFiles": "npm run build && git add dist"
+      },
       "foundry-release-git",
       "foundry-release-npm",
       "foundry-release-bower"


### PR DESCRIPTION
For releases, I have been using `foundry` to manage the multiple steps. It's super helpful when we need to re-publish when there was a mistake (e.g. typo in README).

``` bash
foundry release 1.0.0
foundry release 1.0.1
```

In this PR:
- Added documentation for `foundry`
- Added `npm run build` to foundry release steps (to guarantee most recent `dist` directory)

/cc @gmusic-utils/gmusic-js 
