### PR TITLE
Removed whitelist for .travis.yml branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,6 @@ language: node_js
 node_js:
   - "4.2"
 
-# To reduce noise for other contributors,
-# we are whitelisting Travis CI to only build for `master`
-# DEV: If you would like your branch to build,
-#   then temporarily add it to this list
-#   but also remove `notifications` settings
-branches:
-  only:
-    - master
-
 script:
   # DEV: Currently our test suite runs locally only
   #   This should be resolved in #19


### PR DESCRIPTION
I dropped the ball on https://github.com/gmusic-utils/gmusic.js/pull/19#issuecomment-166038562 but finally picked it back up. In this PR:
- Removed whitelist for `.travis.yml` branches
  - We are going to request maintainers use email filtering to avoid notifications noise

/cc @gmusic-utils/gmusic-js 
