### PR TITLE
Corrected license in package.json to SPDX

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/gmusic-utils/gmusic.js/issues"
   },
-  "licenses": [
-    {
-      "type": "UNLICENSE",
-      "url": "https://github.com/gmusic-utils/gmusic.js/blob/master/UNLICENSE"
-    }
-  ],
+  "license": "Unlicense",
   "main": "lib/main",
   "engines": {
     "node": ">= 0.8.0"


### PR DESCRIPTION
As caught in https://github.com/gmusic-utils/gmusic-theme.js/issues/4, we have been using a deprecated key for our licenses (should be `license` not `licenses`) as well as not the proper SPDX format. This should correct the license link on our `npm` page.

In this PR:
- Moved from `licenses` to `license` key in `package.json`
- Moved to proper license name (`Unlicense` not `UNLICENSE` in `package.json`)
  - http://spdx.org/licenses/

/cc @gmusic-utils/gmusic-js 
