### PR TITLE
Added verification for CHANGELOG being updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # gmusic.js changelog
+4.1.1 - Added CHANGELOG update verification
+
+4.1.0 - Integrated Browserstack to test suite, added `resetRating`, and fixed up failing one-offs
+
 4.0.4 - Corrected documentation of the `change:playback-time` event
 
 4.0.3 - Corrected license in package.json to SPDX

--- a/bin/verify-changelog-updated.js
+++ b/bin/verify-changelog-updated.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Load our dependencies
+var assert = require('assert');
+var fs = require('fs');
+
+// Load in our CHANGELOG
+var content = fs.readFileSync('CHANGELOG.md');
+
+// Verify we have a tag to find
+var version = process.env.FOUNDRY_VERSION;
+assert(version, 'Expected `env.FOUNDRY_VERSION` to be defined but it was not');
+
+// Verify our tag is present in the CHANGELOG
+// e.g. `1.2.3 - Hello world` (single line)
+// e.g. `**1.2.3**\n- Hello world\n- Goodbye moon` (multi-line)
+// DEV: `1.2.3` -> `/\n[^0-9]*1\.2\.3/`
+var versionRegExp = new RegExp('\n[^0-9]*' + version.replace(/\./g, '\\.'));
+if (!versionRegExp.test(content)) {
+  throw new Error('Expected `CHANGELOG.md` to contain "' + version + '" but it wasn\'t found. ' +
+    'Please verify we added `CHANGELOG` notes before releasing.');
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
         "type": "customCommand",
         "updateFiles": "npm run build && git add dist"
       },
+      {
+        "type": "customCommand",
+        "updateFiles": "node bin/verify-changelog-updated.js"
+      },
       "foundry-release-git",
       "foundry-release-npm",
       "foundry-release-bower"


### PR DESCRIPTION
I noticed that while we properly released in #19, we forgot to update the CHANGELOG. As a result, I'm proposing that we solve it programatically. In this PR:
- Added missing CHANGELOG entry
- Added script to verify CHANGELOG has entry for new version

/cc @gmusic-utils/gmusic-js 
