### PR TITLE
Cache observer values for more robust events

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -387,26 +387,40 @@ proto.hooks = {
       });
     });
 
+    var lastShuffle;
     var shuffleObserver = new MutationObserver(function (mutations) {
-      mutations.forEach(function (m) {
+      var shuffleTouched = mutations.some(function (m) {
         var target = m.target;
-        var id = target.dataset.id;
-
-        if (id === SELECTORS.shuffle.dataId) {
-          that.emit('change:shuffle', target.value);
-        }
+        return target.dataset.id === SELECTORS.shuffle.dataId;
       });
+
+      if (!shuffleTouched) {
+        return;
+      }
+
+      var newShuffle = that.playback.getShuffle();
+      if (lastShuffle !== newShuffle) {
+        lastShuffle = newShuffle;
+        that.emit('change:shuffle', newShuffle);
+      }
     });
 
+    var lastRepeat;
     var repeatObserver = new MutationObserver(function (mutations) {
-      mutations.forEach(function (m) {
+      var repeatTouched = mutations.some(function (m) {
         var target = m.target;
-        var id = target.dataset.id;
-
-        if (id === SELECTORS.repeat.dataId) {
-          that.emit('change:repeat', target.value);
-        }
+        return target.dataset.id === SELECTORS.repeat.dataId;
       });
+
+      if (!repeatTouched) {
+        return;
+      }
+
+      var newRepeat = that.playback.getRepeat();
+      if (lastRepeat !== newRepeat) {
+        lastRepeat = newRepeat;
+        that.emit('change:repeat', newRepeat);
+      }
     });
 
     var lastMode;
@@ -459,23 +473,32 @@ proto.hooks = {
       });
     });
 
+    var lastRating;
     var ratingObserver = new MutationObserver(function (mutations) {
-      mutations.forEach(function (m) {
+      // If we are looking at a rating button and it's selected, emit a notification
+      // DEV: Prevent selection of container and "remove-circle-outline" button
+      // jscs:disable maximumLineLength
+      // Good:
+      //   <paper-icon-button icon="sj:thumb-up-outline" data-rating="5" role="button" tabindex="0" aria-disabled="false" class="x-scope paper-icon-button-0" title="Thumb-up" aria-label="Thumb-up"></paper-icon-button>
+      // Bad:
+      //   <div id="playerSongInfo" style=""></div>
+      //   <paper-icon-button icon="remove-circle-outline" data-rating="0" role="button" tabindex="0" aria-disabled="false" class="x-scope paper-icon-button-0"></paper-icon-button>
+      // jscs:enable maximumLineLength
+      var ratingsTouched = mutations.some(function (m) {
+        // Determine if our ratings were touched
         var target = m.target;
-        // If we are looking at a rating button and it's selected, emit a notification
-        // DEV: Prevent selection of container and "remove-circle-outline" button
-        // jscs:disable maximumLineLength
-        // Good:
-        //   <paper-icon-button icon="sj:thumb-up-outline" data-rating="5" role="button" tabindex="0" aria-disabled="false" class="x-scope paper-icon-button-0" title="Thumb-up" aria-label="Thumb-up"></paper-icon-button>
-        // Bad:
-        //   <div id="playerSongInfo" style=""></div>
-        //   <paper-icon-button icon="remove-circle-outline" data-rating="0" role="button" tabindex="0" aria-disabled="false" class="x-scope paper-icon-button-0"></paper-icon-button>
-        // jscs:enable maximumLineLength
-        if (target.dataset && target.dataset.rating !== undefined && target.hasAttribute('aria-label') &&
-            that.rating._isElSelected(target)) {
-          that.emit('change:rating', target.dataset.rating);
-        }
+        return target.dataset && target.dataset.rating && target.hasAttribute('aria-label');
       });
+
+      if (!ratingsTouched) {
+        return;
+      }
+
+      var newRating = that.rating.getRating();
+      if (lastRating !== newRating) {
+        lastRating = newRating;
+        that.emit('change:rating', newRating);
+      }
     });
 
     // Find our target elements

--- a/test/playback.js
+++ b/test/playback.js
@@ -176,7 +176,7 @@ describe('A Google Music instance', function () {
       });
 
       it('was triggered', function () {
-        expect(this.result).to.be.at.least(2);
+        expect(this.result).to.be.at.least(1);
       });
     });
   });


### PR DESCRIPTION
This implements the suggested solution for #33 for the rating, shuffle, and repeat observers.  Interestingly this was already set up for playback mode and song observers, so this PR rounds out the rest.  This should also fix an issue where the `change:repeat` and `change:shuffle`.

Fixes #29.
Fixes #33.
